### PR TITLE
商品一覧表示

### DIFF
--- a/app/assets/stylesheets/module/_products.scss
+++ b/app/assets/stylesheets/module/_products.scss
@@ -225,6 +225,7 @@
       margin: 26px auto;
       display: flex;
       justify-content: space-around;
+
       .category-list{
         background-color: white;
         &__img{
@@ -239,6 +240,25 @@
           margin: 0;
           z-index: auto;
         }
+        // .items-box_photo__sold{
+        //   width: 0;
+        //   height: 0;
+        //   border-top: 60px solid #ea352d ;
+        //   border-right: 60px solid transparent;
+        //   border-bottom: 60px solid transparent;
+        //   border-left: 60px solid #ea352d ;
+        //   z-index:100;
+        //   position: relative;
+        //   top:-320px;
+        //   &__inner{
+        //     transform: rotate(-45deg);
+        //     font-size: 28px;
+        //     margin:-35px 0px 0px -55px;
+        //     color: #fff;
+        //     letter-spacing: 2px;
+        //     font-weight: 600;
+        //   }
+        // }
         &__body{
           width: calc(220px - 16px - 16px);
           text-decoration: none;
@@ -247,6 +267,7 @@
           color: #333;
           padding: 16px;
           &__name{
+            font-size: 30px;
             overflow: hidden;
             line-height: 1.5;
             text-align: left;

--- a/app/assets/stylesheets/module/_products.scss
+++ b/app/assets/stylesheets/module/_products.scss
@@ -228,6 +228,7 @@
 
       .category-list{
         background-color: white;
+        position: relative;
         &__img{
           width: 220px;
           height: 150px;
@@ -240,25 +241,27 @@
           margin: 0;
           z-index: auto;
         }
-        // .items-box_photo__sold{
-        //   width: 0;
-        //   height: 0;
-        //   border-top: 60px solid #ea352d ;
-        //   border-right: 60px solid transparent;
-        //   border-bottom: 60px solid transparent;
-        //   border-left: 60px solid #ea352d ;
-        //   z-index:100;
-        //   position: relative;
-        //   top:-320px;
-        //   &__inner{
-        //     transform: rotate(-45deg);
-        //     font-size: 28px;
-        //     margin:-35px 0px 0px -55px;
-        //     color: #fff;
-        //     letter-spacing: 2px;
-        //     font-weight: 600;
-        //   }
-        // }
+        .items-box_photo__sold{
+          width: 0;
+          height: 0;
+          border-top: 60px solid #ea352d ;
+          border-right: 60px solid transparent;
+          border-bottom: 60px solid transparent;
+          border-left: 60px solid #ea352d ;
+          z-index:100;
+          position: relative;
+          position: absolute;
+          top:0;
+          left:0;
+          &__inner{
+            transform: rotate(-45deg);
+            font-size: 24px;
+            margin:-35px 0px 0px -55px;
+            color: #fff;
+            letter-spacing: 2px;
+            font-weight: 600;
+          }
+        }
         &__body{
           width: calc(220px - 16px - 16px);
           text-decoration: none;

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,6 +1,9 @@
 class ProductsController < ApplicationController
 
   def index
+    @products = Product.all.order('id DESC').limit(5)
+    # where(category_id:1..1000)
+    #.where.not(condition:1).where(condition:0)
   end
 
   def show

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,7 +1,7 @@
 class ProductsController < ApplicationController
 
   def index
-    @products = Product.all.order('id DESC').limit(5)
+    @products = Product.all.order('id DESC').limit(4)
   end
 
   def show

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -2,8 +2,6 @@ class ProductsController < ApplicationController
 
   def index
     @products = Product.all.order('id DESC').limit(5)
-    # where(category_id:1..1000)
-    #.where.not(condition:1).where(condition:0)
   end
 
   def show

--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -1,2 +1,5 @@
 module ProductsHelper
+  def convert_to_jpy(price)
+    "¥#{price.to_s(:delimited,delimiter: ',')}"
+  end
 end

--- a/app/views/products/index.html.haml
+++ b/app/views/products/index.html.haml
@@ -94,45 +94,54 @@
           = link_to "#" do
             %h3.category-text__title 新規投稿商品
         .category-lists
-          .category-list
-            = link_to "#" do
-              .category-list__img
-                = image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/13/a007.png"
-              .category-list__body
-                %h3.category-list__body__name product3
-                .category-list__body__details
-                  %ul
-                    %li 30000円
-                    %li
-                      %i.fa.fa-star.fa-spin
-                      0
-                  %p (税込)
-          .category-list
-            = link_to "#" do
-              .category-list__img
-                = image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png"
-              .category-list__body
-                %h3.category-list__body__name product2
-                .category-list__body__details
-                  %ul
-                    %li 20000円
-                    %li
-                      %i.far.fa-thumbs-up.faa-wrench.animated
-                      0
-                  %p (税込)
-          .category-list
-            = link_to "#" do
-              .category-list__img
-                = image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/7/a001.png"
-              .category-list__body
-                %h3.category-list__body__name product1
-                .category-list__body__details
-                  %ul
-                    %li 10000円
-                    %li
-                      %i.fa.fa-star.faa-flash
-                      0
-                  %p (税込)
+          - @products.each do |product|
+            -if product.buyer_id.present? 
+              .items-box_photo__sold
+                .items-box_photo__sold__inner
+                  SOLD
+            -else
+              .category-list
+                = link_to "#" do
+                  .category-list__img
+                    = image_tag product.productphotos.first.src.url
+                  .category-list__body
+                    %h3.category-list__body__name 
+                      = product.name
+                    .category-list__body__details
+                      %ul
+                        = convert_to_jpy(product.price)
+                        %li
+                          %i.fa.fa-star.fa-spin
+                          0
+                      %p (税込)
+  
+      -# .top.body__new__item__list
+      -#   - @items1.each do |item|
+      -#     - sold = Transact.find_by(item_id: item.id)
+      -#     - if sold == nil
+      -#       .top.body__new__item__list__show
+      -#         = link_to "", item_path(item)
+      -#         .top.body__new__item__list__show__image
+      -#           = image_tag(item.images.first.image, size: "184x184")
+      -#           %p
+      -#             #{convert_to_jpy(item.price)}
+      -#         .top.body__new__item__list__show__name
+      -#           = item.name
+      -#           .top.body__new__item__list__show__name__opa
+      -#     - else
+      -#       .top.body__new__item__list__sold
+      -#         = link_to "", item_path(item)
+      -#         .top.body__new__item__list__show__image
+      -#           = image_tag(item.images.first.image, size: "184x184")
+      -#           %p
+      -#             #{convert_to_jpy(item.price)}
+      -#         .top.body__new__item__list__show__name
+      -#           = item.name
+      -#           .top.body__new__item__list__show__name__opa
+      -#         .sold
+      -#           .back-color
+      -#             %a
+      -#               SOLD
 
     .pickup-brand
       %h2.brand-subtitle ピックアップブランド

--- a/app/views/products/index.html.haml
+++ b/app/views/products/index.html.haml
@@ -95,53 +95,25 @@
             %h3.category-text__title 新規投稿商品
         .category-lists
           - @products.each do |product|
-            -if product.buyer_id.present? 
-              .items-box_photo__sold
-                .items-box_photo__sold__inner
-                  SOLD
-            -else
-              .category-list
-                = link_to "#" do
-                  .category-list__img
-                    = image_tag product.productphotos.first.src.url
-                  .category-list__body
-                    %h3.category-list__body__name 
-                      = product.name
-                    .category-list__body__details
-                      %ul
-                        = convert_to_jpy(product.price)
-                        %li
-                          %i.fa.fa-star.fa-spin
-                          0
-                      %p (税込)
+            .category-list
+              = link_to "#" do
+                .category-list__img
+                  = image_tag product.productphotos.first.src.url
+                .category-list__body
+                  %h3.category-list__body__name 
+                    = product.name
+                  .category-list__body__details
+                    %ul
+                      = convert_to_jpy(product.price)
+                      %li
+                        %i.fa.fa-star.fa-spin
+                        0
+                    %p (税込)
+              -if product.buyer_id.present? 
+                .items-box_photo__sold
+                  .items-box_photo__sold__inner
+                    SOLD
   
-      -# .top.body__new__item__list
-      -#   - @items1.each do |item|
-      -#     - sold = Transact.find_by(item_id: item.id)
-      -#     - if sold == nil
-      -#       .top.body__new__item__list__show
-      -#         = link_to "", item_path(item)
-      -#         .top.body__new__item__list__show__image
-      -#           = image_tag(item.images.first.image, size: "184x184")
-      -#           %p
-      -#             #{convert_to_jpy(item.price)}
-      -#         .top.body__new__item__list__show__name
-      -#           = item.name
-      -#           .top.body__new__item__list__show__name__opa
-      -#     - else
-      -#       .top.body__new__item__list__sold
-      -#         = link_to "", item_path(item)
-      -#         .top.body__new__item__list__show__image
-      -#           = image_tag(item.images.first.image, size: "184x184")
-      -#           %p
-      -#             #{convert_to_jpy(item.price)}
-      -#         .top.body__new__item__list__show__name
-      -#           = item.name
-      -#           .top.body__new__item__list__show__name__opa
-      -#         .sold
-      -#           .back-color
-      -#             %a
-      -#               SOLD
 
     .pickup-brand
       %h2.brand-subtitle ピックアップブランド


### PR DESCRIPTION
#33 商品一覧表示の実装

#33 
①商品出品した物がトップページの一覧にアップされる。（最大表示数4件）
②ログアウト時でも一覧表示される。
③購入された時（buyer_idがpresenseの時）、一覧表示の写真に「SOLD」の文字が表示される。

◼参考画像
①https://i.gyazo.com/efcca6872202480af9e6618e146d40b2.gif
②https://i.gyazo.com/bbaf81eb87781cab9220ad7f538a9e52.gif
③https://i.gyazo.com/d64aa02f790a603b96b235427b63be21.gif