### PR TITLE
update payjp.js／sessions/new.html.haml

### DIFF
--- a/app/assets/javascripts/payjp.js
+++ b/app/assets/javascripts/payjp.js
@@ -1,38 +1,36 @@
-document.addEventListener(
-  "DOMContentLoaded", e => {
-    if (document.getElementById("token_submit") != null) {
-      Payjp.setPublicKey("pk_test_c80b1ebadce1c185f9621851");
+document.addEventListener("turbolinks:load", function() {  
+  if (document.getElementById("token_submit") != null) {
+    Payjp.setPublicKey("pk_test_c80b1ebadce1c185f9621851");
 
-      let btn = document.getElementById("token_submit");
+    let btn = document.getElementById("token_submit");
 
-      btn.addEventListener("click", e => {
-        e.preventDefault();
-        let card = {
-          number: document.getElementById("card_number").value,
-          cvc: document.getElementById("cvc").value,
-          exp_month: document.getElementById("exp_month").value,
-          exp_year: document.getElementById("exp_year").value
-        };
+    btn.addEventListener("click", e => {
+      e.preventDefault();
+      let card = {
+        number: document.getElementById("card_number").value,
+        cvc: document.getElementById("cvc").value,
+        exp_month: document.getElementById("exp_month").value,
+        exp_year: document.getElementById("exp_year").value
+      };
 
-        Payjp.createToken(card, (status, response) => {
-          if (status === 200) {
-            $("#card_number").removeAttr("name");
-            $("#cvc").removeAttr("name");
-            $("#exp_month").removeAttr("name");
-            $("#exp_year").removeAttr("name");
-            $("#card_token").append(
-              $('<input type="hidden" name="payjp-token">').val(response.id)
-            );
+      Payjp.createToken(card, (status, response) => {
+        if (status === 200) {
+          $("#card_number").removeAttr("name");
+          $("#cvc").removeAttr("name");
+          $("#exp_month").removeAttr("name");
+          $("#exp_year").removeAttr("name");
+          $("#card_token").append(
+            $('<input type="hidden" name="payjp-token">').val(response.id)
+          );
 
-            document.inputForm.submit();
-            alert("登録が完了しました");
+          document.inputForm.submit();
+          alert("登録が完了しました");
 
-          } else {
-            alert("カード情報が正しくありません。"); //確認用
-          }
-        });
+        } else {
+          alert("カード情報が正しくありません。"); //確認用
+        }
       });
-    }
-  },
+    });
+  }
   false
-);
+});

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -7,7 +7,7 @@
         %p アカウントをお持ちでない方
         %a(href= "/users/sign_up")新規会員登録
       .login__content__form
-        = link_to "#", class: "default__btn default__btn--google" do
+        = link_to new_user_registration_path, class: "default__btn default__btn--google" do
           = icon('fab', 'google',  class: "contents__btn--icon")
           Googleでログイン
         = link_to "#", class: "default__btn default__btn--facebook" do


### PR DESCRIPTION
 # What
- turbolinks:load を追加
1度で登録できなかったエラーを解消、一度で登録できるようにした
```
"DOMContentLoaded", e => {
```
これが作用して通常なら読み込みをはやくするためのturbolinksの動きを邪魔していた模様

- ログイン画面から新規登録のパス追加
link_to "#" のところを link_to new_session_path に変更して新規登録画面に遷移できるようにした