### PR TITLE
表示不具合修正と遷移先変更

### DIFF
--- a/app/models/postagepayer.rb
+++ b/app/models/postagepayer.rb
@@ -1,6 +1,5 @@
 class Postagepayer < ActiveHash::Base
   self.data = [
-  {id: 0, name: '選択してください'},
-  {id: 1, name: '送料込み（出品者負担）'}, {id: 2, name: '着払い（購入者負担）'}
+  {id: 0, name: '送料込み（出品者負担）'}, {id: 1, name: '着払い（購入者負担）'}
   ]
 end

--- a/app/views/products/_form.html.haml
+++ b/app/views/products/_form.html.haml
@@ -125,7 +125,7 @@
             .buttons    
               = f.submit "出品する", class: "buttons__sell"
               .buttons__save 下書きに保存
-              =link_to "product_path" do
+              =link_to root_path do
                 .buttons__back もどる
               .warning
                 禁止されている行為および出品物を必ずご確認ください。偽ブランド品や盗品物などの販売は犯罪であり、法律により処罰される可能性があります。 また、出品をもちまして加盟店規約に同意したことになります。


### PR DESCRIPTION
#what
出品機能の選択してくださいが二個表示されるのを修正
戻るボタンの遷移先をトップページに変更
#why
選択していくださいが二個出たら変だから。
商品がない場合エラーが発生するから